### PR TITLE
Radiobuttons toegevoegd aan het start match scherm

### DIFF
--- a/DARTS/View/StartMatchView.xaml
+++ b/DARTS/View/StartMatchView.xaml
@@ -40,7 +40,7 @@
         </TextBox>
 
         <Label Content="Choose starting player" Canvas.Left="631" Canvas.Top="150" FontSize="20" Width="226"/>
-        <ComboBox IsEditable="False" x:Name="PlayersCombo" Canvas.Left="631" Canvas.Top="183" Width="221" Height="30" SelectedIndex="0">
+        <ComboBox IsEditable="False" x:Name="PlayersCombo" Canvas.Left="631" Canvas.Top="183" Width="221" Height="30" SelectedIndex="0" VerticalContentAlignment="Center">
             <ComboBoxItem Content="Random" FontSize="15"></ComboBoxItem>
             <ComboBoxItem Content="Player one" FontSize="15"></ComboBoxItem>
             <ComboBoxItem Content="Player two" FontSize="15"></ComboBoxItem>
@@ -57,6 +57,10 @@
                 </Binding>
             </TextBox.Text>
         </TextBox>
+
+        <TextBlock Text="Amount of points per leg" Canvas.Top="260" FontSize="20" Canvas.Left="631" Width="320"/>
+        <RadioButton GroupName="pointsPerLeg" Content="501" Canvas.Left="631" Canvas.Top="289" FontSize="15" VerticalContentAlignment="Center" IsChecked="True"/>
+        <RadioButton GroupName="pointsPerLeg" Content="301" Canvas.Left="631" Canvas.Top="312" FontSize="15" VerticalContentAlignment="Center"/>
 
         <Label Content="Enter amount of legs per set" Canvas.Left="65" Canvas.Top="350" FontSize="20" Width="320"/>
         <TextBox Name="tbLegsInSet" TextWrapping="Wrap" Width="320" Canvas.Left="65" Canvas.Top="392" Height="30"

--- a/DARTS/ViewModel/StartMatchViewModel.cs
+++ b/DARTS/ViewModel/StartMatchViewModel.cs
@@ -57,6 +57,5 @@ namespace DARTS.ViewModel
         {
             return true;
         }
-        
     }
 }


### PR DESCRIPTION
### Omschrijving

Radiobuttons toegevoegd aan het start match scherm zodat na integratie met de backend geselecteerd kan worden hoeveel punten er per leg behaald moeten worden.

**Risico's**

Laag risico: UI aanpassing

---
### Tests
**Test 1 "Keuze maken" :**

Voorbereiding:
- Start het programma op.
- Klik op de "Start match scherm" knop

Test
- Controleer of de "501" checkbox is aangevinkt bij "Amount of points per leg"
- Klik de "301" checkbox aan 
- Controleer of de "301" checkbox is aangevinkt bij "Amount of points per leg" 
- Controleer of de "501" checkbox niet meer is aangevinkt

Geslaagd als :
De "501" checkbox is aangevinkt en de andere checkbox aangevinkt kan worden

---

closes #52 