### PR TITLE
Implemented #82 keuze legscore

### DIFF
--- a/DARTS/Data/DataObjectFactories/MatchFactory.cs
+++ b/DARTS/Data/DataObjectFactories/MatchFactory.cs
@@ -25,6 +25,7 @@ namespace DARTS.Data.DataObjectFactories
             _fieldCollection.Add(MatchFieldNames.NumLegs, new DataField(MatchFieldNames.NumLegs, SQLiteType.INTEGER));
             _fieldCollection.Add(MatchFieldNames.Player1SetsWon, new DataField(MatchFieldNames.Player1SetsWon, SQLiteType.INTEGER));
             _fieldCollection.Add(MatchFieldNames.Player2SetsWon, new DataField(MatchFieldNames.Player2SetsWon, SQLiteType.INTEGER));
+            _fieldCollection.Add(MatchFieldNames.PointsPerLeg, new DataField(MatchFieldNames.PointsPerLeg, SQLiteType.INTEGER));
 
             _objectFieldCollection.Add(MatchFieldNames.Player1, new ObjectField(MatchFieldNames.Player1, typeof(PlayerFactory), player1IdField));
             _objectFieldCollection.Add(MatchFieldNames.Player2, new ObjectField(MatchFieldNames.Player2, typeof(PlayerFactory), player2IdField));
@@ -54,5 +55,6 @@ namespace DARTS.Data.DataObjectFactories
         public const string NumLegs = "NumLegs";
         public const string Player1SetsWon = "Player1SetsWon";
         public const string Player2SetsWon = "Player2SetsWon";
+        public const string PointsPerLeg = "PointsPerLeg";
     }
 }

--- a/DARTS/Data/DataObjects/Leg.cs
+++ b/DARTS/Data/DataObjects/Leg.cs
@@ -10,6 +10,7 @@ namespace DARTS.Data.DataObjects
     public class Leg : DataObjectBase
     {
         #region Properties
+        private int PlayerPoints { get; set; }
         public long Id
         {
             get => (long)FieldCollection[LegFieldNames.Id].Value;

--- a/DARTS/Data/DataObjects/Match.cs
+++ b/DARTS/Data/DataObjects/Match.cs
@@ -27,6 +27,11 @@ namespace DARTS.Data.DataObjects
             get => (long)FieldCollection[MatchFieldNames.Player2Id].Value;
             set => FieldCollection[MatchFieldNames.Player2Id].Value = value;
         }
+        public int pointsPerLeg
+        {
+            get => (int)FieldCollection[MatchFieldNames.PointsPerLeg].Value;
+            set => FieldCollection[MatchFieldNames.PointsPerLeg].Value = value;
+        }
         public DataObjectBase Player1
         {
             get => (DataObjectBase)ObjectFieldCollection[MatchFieldNames.Player1].Value;
@@ -128,7 +133,8 @@ namespace DARTS.Data.DataObjects
             newSet.SetState = PlayState.InProgress;
             newSet.Player1LegsWon = 0;
             newSet.Player2LegsWon = 0;
-           // newSet.Post();
+            newSet.PlayerPoints = pointsPerLeg;
+
             return newSet;
         }
 

--- a/DARTS/Data/DataObjects/Set.cs
+++ b/DARTS/Data/DataObjects/Set.cs
@@ -8,7 +8,7 @@ namespace DARTS.Data.DataObjects
 {
     public class Set : DataObjectBase
     {
-        private const int PlayerPoints = 501;
+        public int PlayerPoints { get; set; }
 
         public long Id
         {
@@ -94,8 +94,8 @@ namespace DARTS.Data.DataObjects
         public Leg CreateNewLeg()
         {
             Leg newLeg = (Leg)LegFactory.Spawn();
-            newLeg.Player1LegScore = PlayerPoints;
-            newLeg.Player2LegScore = PlayerPoints;
+            newLeg.Player1LegScore = (uint)PlayerPoints;
+            newLeg.Player2LegScore = (uint)PlayerPoints;
             newLeg.LegState = PlayState.InProgress;
 
             return newLeg;

--- a/DARTS/ViewModel/StartMatchViewModel.cs
+++ b/DARTS/ViewModel/StartMatchViewModel.cs
@@ -21,6 +21,7 @@ namespace DARTS.ViewModel
         public string Player2 { get; set; }
         public int NumSets { get; set; }
         public int NumLegs { get; set; }
+        public bool Is501LegScore { get; set; }
         public PlayerEnum[] PlayerEnums { get; set; }
         public PlayerEnum SelectedPlayerEnum { get; set; }
 
@@ -35,6 +36,7 @@ namespace DARTS.ViewModel
             StartMatchButtonClickCommand = new RelayCommand(execute => StartMatchButton_Click(), canExecute => CanExecuteStartMatchButtonClick());
             BackToMainMenuButtonClickCommand = new RelayCommand(execute => BackToMainMenuButton_Click());
 
+            Is501LegScore = true;
             PlayerEnums = (PlayerEnum[])Enum.GetValues(typeof(PlayerEnum));
             PlayerFactory = new PlayerFactory();
             MatchFactory = new MatchFactory();
@@ -68,6 +70,7 @@ namespace DARTS.ViewModel
             match.MatchState = PlayState.InProgress;
             match.NumSets = NumSets;
             match.NumLegs = NumLegs;
+            match.pointsPerLeg = Is501LegScore ? 501 : 301;
 
             match.Start();
             GameInstance.Instance.MainWindow.ChangeToScoreInputView(match);

--- a/DARTS/Views/StartMatchView.xaml
+++ b/DARTS/Views/StartMatchView.xaml
@@ -50,7 +50,7 @@
         </TextBox>
 
         <TextBlock Text="Amount of points per leg" Canvas.Top="180" FontSize="20" Canvas.Left="535" Width="226"/>
-        <RadioButton GroupName="pointsPerLeg" Content="501" Canvas.Left="535" Canvas.Top="209" FontSize="15" VerticalContentAlignment="Center" IsChecked="True"/>
+        <RadioButton GroupName="pointsPerLeg" Content="501" Canvas.Left="535" Canvas.Top="209" FontSize="15" VerticalContentAlignment="Center" IsChecked="{Binding Is501LegScore}"/>
         <RadioButton GroupName="pointsPerLeg" Content="301" Canvas.Left="535" Canvas.Top="232" FontSize="15" VerticalContentAlignment="Center"/>
 
         <Label Content="Enter amount of legs per set" Canvas.Left="35" Canvas.Top="270" FontSize="20" Width="320"/>

--- a/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
@@ -39,6 +39,7 @@ namespace DARTS_UnitTests.Datastructuur
             match.NumLegs = numLegs;
             match.BeginningPlayer = beginningPlayer;
             match.MatchState = PlayState.InProgress;
+            match.pointsPerLeg = 501;
 
             this.match = match;
         }


### PR DESCRIPTION
Co-Authored-By: Swen van der Wijngaard <32259799+SwenvdWijngaard@users.noreply.github.com>

### Omschrijving
Waarde van de radiobuttons voor legscore op het start match scherm worden nu ook daadwerkelijk gebruikt in de match back-end om de points per leg in de match te bepalen.

**Risico's**
Laag risico, simpele aanpassing.
---
### Tests
**Test 1 "Start match met 501 required leg score" :**

Voorbereiding:
- Start het programma op.
- Klik op knop "Open start match scherm".
- Vul "Bob" in bij de naam van player 1.
- Vul "Bib" in bij de naam van player 2.
- Vul "1" in bij de sets en legs.

Test
- Klik op de "Start match" knop.

Geslaagd als :
De "Score" bij beide spelers 501 aangeeft.

---

**Test 2 "Start match met 301 required leg score" :**

Voorbereiding:
- Start het programma op.
- Klik op knop "Open start match scherm".
- Vul "Bob" in bij de naam van player 1.
- Vul "Bib" in bij de naam van player 2.
- Vul "1" in bij de sets en legs.
- Klik de 301 optie aan bij de amount of points per leg.

Test
- Klik op de "Start match" knop.

Geslaagd als :
De "Score" bij beide spelers 301 aangeeft.

---
