### PR TITLE
Fixed #89 in de match data object structuur.

### DIFF
--- a/DARTS/Data/DataObjects/Leg.cs
+++ b/DARTS/Data/DataObjects/Leg.cs
@@ -10,7 +10,6 @@ namespace DARTS.Data.DataObjects
     public class Leg : DataObjectBase
     {
         #region Properties
-        private int PlayerPoints { get; set; }
         public long Id
         {
             get => (long)FieldCollection[LegFieldNames.Id].Value;
@@ -22,6 +21,7 @@ namespace DARTS.Data.DataObjects
             get => (long)FieldCollection[LegFieldNames.SetId].Value;
             set => FieldCollection[LegFieldNames.SetId].Value = value;
         }
+
         public BindingList<DataObjectBase> Turns
         {
             get => CollectionFieldCollection[LegFieldNames.Turns].Value;
@@ -30,31 +30,31 @@ namespace DARTS.Data.DataObjects
 
         public PlayerEnum WinningPlayer
         {
-            get => (PlayerEnum)FieldCollection[LegFieldNames.WinningPlayer].Value;
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[LegFieldNames.WinningPlayer].Value);
             set => FieldCollection[LegFieldNames.WinningPlayer].Value = (int)value;
         }
 
         public PlayerEnum BeginningPlayer
         {
-            get => (PlayerEnum)(int)FieldCollection[LegFieldNames.BeginningPlayer].Value;
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[LegFieldNames.BeginningPlayer].Value);
             set => FieldCollection[LegFieldNames.BeginningPlayer].Value = (int)value;
         }
 
         public PlayState LegState
         {
-            get => (PlayState)(int)FieldCollection[LegFieldNames.LegState].Value;        
+            get => (PlayState)Convert.ToInt32(FieldCollection[LegFieldNames.LegState].Value);        
             set => FieldCollection[LegFieldNames.LegState].Value = (int)value;
         }
 
         public uint Player1LegScore
         {
-            get => (uint)FieldCollection[LegFieldNames.Player1LegScore].Value;
+            get => Convert.ToUInt32(FieldCollection[LegFieldNames.Player1LegScore].Value);
             set => FieldCollection[LegFieldNames.Player1LegScore].Value = value;
         }
 
         public uint Player2LegScore
         {
-            get => (uint)FieldCollection[LegFieldNames.Player2LegScore].Value;
+            get => Convert.ToUInt32(FieldCollection[LegFieldNames.Player2LegScore].Value);
             set => FieldCollection[LegFieldNames.Player2LegScore].Value = value;
         }
 
@@ -84,6 +84,7 @@ namespace DARTS.Data.DataObjects
             }            
         }
         #endregion
+
         private TurnFactory TurnFactory
         {
             get;

--- a/DARTS/Data/DataObjects/Match.cs
+++ b/DARTS/Data/DataObjects/Match.cs
@@ -22,16 +22,19 @@ namespace DARTS.Data.DataObjects
             get => (long)FieldCollection[MatchFieldNames.Player1Id].Value;
             set => FieldCollection[MatchFieldNames.Player1Id].Value = value;
         }
+
         public long Player2Id
         {
             get => (long)FieldCollection[MatchFieldNames.Player2Id].Value;
             set => FieldCollection[MatchFieldNames.Player2Id].Value = value;
         }
-        public int pointsPerLeg
+
+        public int PointsPerLeg
         {
-            get => (int)FieldCollection[MatchFieldNames.PointsPerLeg].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.PointsPerLeg].Value);
             set => FieldCollection[MatchFieldNames.PointsPerLeg].Value = value;
         }
+
         public DataObjectBase Player1
         {
             get => (DataObjectBase)ObjectFieldCollection[MatchFieldNames.Player1].Value;
@@ -46,19 +49,19 @@ namespace DARTS.Data.DataObjects
 
         public PlayerEnum WinningPlayer
         {
-            get => (PlayerEnum)((int)FieldCollection[MatchFieldNames.WinningPlayer].Value);
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[MatchFieldNames.WinningPlayer].Value);
             set => FieldCollection[MatchFieldNames.WinningPlayer].Value = (int)value;
         }
 
         public PlayerEnum BeginningPlayer
         {
-            get => (PlayerEnum)((int)FieldCollection[MatchFieldNames.BeginningPlayer].Value);
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[MatchFieldNames.BeginningPlayer].Value);
             set => FieldCollection[MatchFieldNames.BeginningPlayer].Value = (int)value;
         }
 
         public PlayState MatchState
         {
-            get => (PlayState)((int)FieldCollection[MatchFieldNames.MatchState].Value);
+            get => (PlayState)Convert.ToInt32(FieldCollection[MatchFieldNames.MatchState].Value);
             set => FieldCollection[MatchFieldNames.MatchState].Value = (int)value;
         }
 
@@ -70,7 +73,7 @@ namespace DARTS.Data.DataObjects
 
         public int NumSets
         {
-            get => (int)FieldCollection[MatchFieldNames.NumSets].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.NumSets].Value);
             set
             {
                 if (value % 2 == 0)
@@ -83,7 +86,7 @@ namespace DARTS.Data.DataObjects
 
         public int NumLegs
         {
-            get => (int)FieldCollection[MatchFieldNames.NumLegs].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.NumLegs].Value);
             set
             {
                 if (value % 2 == 0)
@@ -96,7 +99,7 @@ namespace DARTS.Data.DataObjects
 
         public int Player1SetsWon
         {
-            get => (int)FieldCollection[MatchFieldNames.Player1SetsWon].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.Player1SetsWon].Value);
             set
             {
                 if (value > NumSets)
@@ -109,7 +112,7 @@ namespace DARTS.Data.DataObjects
 
         public int Player2SetsWon
         {
-            get => (int)FieldCollection[MatchFieldNames.Player2SetsWon].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.Player2SetsWon].Value);
             set
             {
                 if (value > NumSets)
@@ -133,15 +136,18 @@ namespace DARTS.Data.DataObjects
             newSet.SetState = PlayState.InProgress;
             newSet.Player1LegsWon = 0;
             newSet.Player2LegsWon = 0;
-            newSet.PlayerPoints = pointsPerLeg;
+            newSet.PlayerPoints = PointsPerLeg;
 
             return newSet;
         }
 
         public void Start()
         {
+            MatchState = PlayState.InProgress;
+            WinningPlayer = PlayerEnum.None;
             Player1SetsWon = 0;
             Player2SetsWon = 0;
+
             Sets = new BindingList<DataObjectBase>();
             SetFactory = new SetFactory();
             if (BeginningPlayer.Equals(PlayerEnum.None))
@@ -149,12 +155,12 @@ namespace DARTS.Data.DataObjects
                 BeginningPlayer = ChooseRandomPlayer();
             }
 
-            // TODO: impement factory pattern.
             Set firstSet = CreateNewSet();
             firstSet.BeginningPlayer = BeginningPlayer;
             Sets.Add(firstSet);
             firstSet.Start();
         }
+
         /// <summary>
         /// Called in ChangeTurn()
         /// Checks if the math has been won.
@@ -193,6 +199,7 @@ namespace DARTS.Data.DataObjects
 
             return WinningPlayer;
         }
+
         /// <summary>
         /// Starts the next turn and assigns the right player..
         /// Uses CheckWin methods to see if a new Leg or Set must be created and creates them if needed.

--- a/DARTS/Data/DataObjects/Set.cs
+++ b/DARTS/Data/DataObjects/Set.cs
@@ -30,25 +30,25 @@ namespace DARTS.Data.DataObjects
 
         public PlayerEnum WinningPlayer
         {
-            get => (PlayerEnum)((int)FieldCollection[SetFieldNames.WinningPlayer].Value);
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[SetFieldNames.WinningPlayer].Value);
             set => FieldCollection[SetFieldNames.WinningPlayer].Value = (int)value;
         }
 
         public PlayerEnum BeginningPlayer
         {
-            get => (PlayerEnum)((int)FieldCollection[SetFieldNames.BeginningPlayer].Value);
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[SetFieldNames.BeginningPlayer].Value);
             set => FieldCollection[SetFieldNames.BeginningPlayer].Value = (int)value;
         }
 
         public PlayState SetState
         {
-            get => (PlayState)((int)FieldCollection[SetFieldNames.SetState].Value);
+            get => (PlayState)Convert.ToInt32(FieldCollection[SetFieldNames.SetState].Value);
             set => FieldCollection[SetFieldNames.SetState].Value = (int)value;
         }
 
         public int NumLegs
         {
-            get => (int)FieldCollection[MatchFieldNames.NumLegs].Value;
+            get => Convert.ToInt32(FieldCollection[MatchFieldNames.NumLegs].Value);
             set
             {
                 if (value % 2 == 0)
@@ -61,7 +61,7 @@ namespace DARTS.Data.DataObjects
 
         public int Player1LegsWon
         {
-            get => (int)FieldCollection[SetFieldNames.Player1LegsWon].Value;
+            get => Convert.ToInt32(FieldCollection[SetFieldNames.Player1LegsWon].Value);
             set
             {
                 if (value > NumLegs)
@@ -74,7 +74,7 @@ namespace DARTS.Data.DataObjects
 
         public int Player2LegsWon
         {
-            get => (int)FieldCollection[SetFieldNames.Player2LegsWon].Value;
+            get => Convert.ToInt32(FieldCollection[SetFieldNames.Player2LegsWon].Value);
             set
             {
                 if (value > NumLegs)

--- a/DARTS/Data/DataObjects/Throw.cs
+++ b/DARTS/Data/DataObjects/Throw.cs
@@ -21,17 +21,13 @@ namespace DARTS.Data.DataObjects
 
         public int Score
         {
-            get => (int)FieldCollection[ThrowFieldNames.Score].Value;
+            get => Convert.ToInt32(FieldCollection[ThrowFieldNames.Score].Value);
             set => FieldCollection[ThrowFieldNames.Score].Value = value;
         }
 
         public ScoreType ScoreType
         {
-            get
-            {
-                int intVal = (int)FieldCollection[ThrowFieldNames.ScoreType].Value;
-                return (ScoreType)intVal;
-            }
+            get => (ScoreType)Convert.ToInt32(FieldCollection[ThrowFieldNames.ScoreType].Value);
             set => FieldCollection[ThrowFieldNames.ScoreType].Value = (int)value;
         }
     }

--- a/DARTS/Data/DataObjects/Turn.cs
+++ b/DARTS/Data/DataObjects/Turn.cs
@@ -8,6 +8,7 @@ namespace DARTS.Data.DataObjects
 {
     public class Turn : DataObjectBase
     {
+        #region Properties
         public long Id
         {
             get => (long)FieldCollection[TurnFieldNames.Id].Value;
@@ -19,15 +20,10 @@ namespace DARTS.Data.DataObjects
             get => (long)FieldCollection[TurnFieldNames.LegId].Value;
             set => FieldCollection[TurnFieldNames.LegId].Value = value;
         }
-
-        #region Properties
+        
         public PlayerEnum PlayerTurn
         {
-            get
-            {
-                int intVal = (int)FieldCollection[TurnFieldNames.PlayerTurn].Value;
-                return (PlayerEnum)intVal;
-            }
+            get => (PlayerEnum)Convert.ToInt32(FieldCollection[TurnFieldNames.PlayerTurn].Value);
             set => FieldCollection[TurnFieldNames.PlayerTurn].Value = (int)value; 
         }
 

--- a/DARTS/ViewModel/StartMatchViewModel.cs
+++ b/DARTS/ViewModel/StartMatchViewModel.cs
@@ -70,7 +70,7 @@ namespace DARTS.ViewModel
             match.MatchState = PlayState.InProgress;
             match.NumSets = NumSets;
             match.NumLegs = NumLegs;
-            match.pointsPerLeg = Is501LegScore ? 501 : 301;
+            match.PointsPerLeg = Is501LegScore ? 501 : 301;
 
             match.Start();
             GameInstance.Instance.MainWindow.ChangeToScoreInputView(match);

--- a/DARTS_UnitTests/Data/DataObjects/Leg_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Leg_UnitTest.cs
@@ -1,0 +1,31 @@
+﻿using DARTS.Data.DataObjectFactories;
+using DARTS.Data.DataObjects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DARTS_UnitTests.Data.DataObjects
+{
+    [TestClass]
+    public class Leg_UnitTest
+    {
+        [TestMethod]
+        public void Reading_Leg_Properties_Should_Not_Cause_Exceptions()
+        {
+            LegFactory legFactory = new LegFactory();
+            Leg leg = (Leg)legFactory.Spawn();
+            leg.WinningPlayer = PlayerEnum.Player1;
+            leg.BeginningPlayer = PlayerEnum.Player1;
+            leg.LegState = PlayState.InProgress;
+            leg.Player1LegScore = 1;
+            leg.Player2LegScore = 0;
+
+            leg.Post();
+            leg = (Leg)legFactory.Get(leg.Id);
+
+            Assert.IsNotNull(leg.WinningPlayer);
+            Assert.IsNotNull(leg.BeginningPlayer);
+            Assert.IsNotNull(leg.LegState);
+            Assert.IsNotNull(leg.Player1LegScore);
+            Assert.IsNotNull(leg.Player2LegScore);
+        }
+    }
+}

--- a/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Windows;
 using DARTS.Data.DataObjectFactories;
+using DARTS_UnitTests.ViewModel;
 
 namespace DARTS_UnitTests.Datastructuur
 {
@@ -39,7 +40,7 @@ namespace DARTS_UnitTests.Datastructuur
             match.NumLegs = numLegs;
             match.BeginningPlayer = beginningPlayer;
             match.MatchState = PlayState.InProgress;
-            match.pointsPerLeg = 501;
+            match.PointsPerLeg = 501;
 
             this.match = match;
         }
@@ -230,6 +231,30 @@ namespace DARTS_UnitTests.Datastructuur
 
             //Assert
             Assert.AreEqual(match.GetCurrentLeg().Player1LegScore, StartingLegScore);
+        }
+
+        [TestMethod]
+        public void Reading_Match_Properties_Should_Not_Cause_Exceptions()
+        {
+            match.Start();
+            match.Post();
+            MatchFactory fact = new MatchFactory();
+            match = (Match)fact.Get(match.Id);
+
+            Assert.IsNotNull(match.Id);
+            Assert.IsNotNull(match.Player1Id);
+            Assert.IsNotNull(match.Player2Id);
+            Assert.IsNotNull(match.PointsPerLeg);
+            Assert.IsNotNull(match.Player1);
+            Assert.IsNotNull(match.Player2);
+            Assert.IsNotNull(match.WinningPlayer);
+            Assert.IsNotNull(match.BeginningPlayer);
+            Assert.IsNotNull(match.MatchState);
+            Assert.IsNotNull(match.Sets);
+            Assert.IsNotNull(match.NumLegs);
+            Assert.IsNotNull(match.NumSets);
+            Assert.IsNotNull(match.Player1SetsWon);
+            Assert.IsNotNull(match.Player2SetsWon);
         }
     }
 }

--- a/DARTS_UnitTests/Data/DataObjects/Set_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Set_UnitTest.cs
@@ -41,5 +41,28 @@ namespace DARTS_UnitTests.Data.DataObjects
             // Assert.
             Assert.IsNotNull(set.MatchId);
         }
+
+        [TestMethod]
+        public void Reading_Set_Properties_Should_Not_Cause_Exceptions()
+        {
+            SetFactory setFactory = new SetFactory();
+            Set set = (Set)setFactory.Spawn();
+            set.WinningPlayer = PlayerEnum.Player1;
+            set.BeginningPlayer = PlayerEnum.Player1;
+            set.SetState = PlayState.InProgress;
+            set.NumLegs = 1;
+            set.Player1LegsWon = 0;
+            set.Player2LegsWon = 0;
+
+            set.Post();
+            set = (Set)setFactory.Get(set.Id);
+
+            Assert.IsNotNull(set.WinningPlayer);
+            Assert.IsNotNull(set.BeginningPlayer);
+            Assert.IsNotNull(set.SetState);
+            Assert.IsNotNull(set.NumLegs);
+            Assert.IsNotNull(set.Player1LegsWon);
+            Assert.IsNotNull(set.Player2LegsWon);
+        }
     }
 }

--- a/DARTS_UnitTests/Data/DataObjects/Throw_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Throw_UnitTest.cs
@@ -1,0 +1,25 @@
+﻿using DARTS.Data.DataObjectFactories;
+using DARTS.Data.DataObjects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DARTS_UnitTests.Data.DataObjects
+{
+    [TestClass]
+    public class Throw_UnitTest
+    {
+        [TestMethod]
+        public void Reading_Throw_Properties_Should_Not_Cause_Exceptions()
+        {
+            ThrowFactory throwFactory = new ThrowFactory();
+            Throw dartThrow = (Throw)throwFactory.Spawn();
+            dartThrow.Score = 2;
+            dartThrow.ScoreType = ScoreType.Single;
+
+            dartThrow.Post();
+            dartThrow = (Throw)throwFactory.Get(dartThrow.Id);
+
+            Assert.IsNotNull(dartThrow.Score);
+            Assert.IsNotNull(dartThrow.ScoreType);
+        }
+    }
+}

--- a/DARTS_UnitTests/Data/DataObjects/Turn_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Turn_UnitTest.cs
@@ -41,5 +41,18 @@ namespace DARTS_UnitTests.Data.DataObjects
             // Assert.
             Assert.IsNotNull(turn.LegId);
         }
+
+        [TestMethod]
+        public void Reading_Turn_Properties_Should_Not_Cause_Exceptions()
+        {
+            TurnFactory turnFactory = new TurnFactory();
+            Turn turn = (Turn)turnFactory.Spawn();
+            turn.PlayerTurn = PlayerEnum.Player1;
+
+            turn.Post();
+            turn = (Turn)turnFactory.Get(turn.Id);
+
+            Assert.IsNotNull(turn.PlayerTurn);
+        }
     }
 }


### PR DESCRIPTION
### Omschrijving
Bug waar de data in de database niet ingeladen kon worden in de desbetreffende properties vanwege een casting exception.

**Risico's**
Laag risico, bugfix.

---
### Tests
Zie aangemaakte Unit Tests.