### PR TITLE
#98 PlayerScore can end on 1 Bugfix

### DIFF
--- a/DARTS/Data/DataObjects/Leg.cs
+++ b/DARTS/Data/DataObjects/Leg.cs
@@ -150,7 +150,7 @@ namespace DARTS.Data.DataObjects
         {
             foreach (Throw dart in ((Turn)Turns.Last()).Throws)
             {
-                if (CurrentPlayerLegScore > dart.Score) CurrentPlayerLegScore -= (uint)dart.Score;
+                if (CurrentPlayerLegScore > dart.Score && CurrentPlayerLegScore - (uint)dart.Score != 1) CurrentPlayerLegScore -= (uint)dart.Score;
                 else if (CurrentPlayerLegScore == dart.Score)
                 {
                     if (dart.ScoreType == ScoreType.Double || dart.ScoreType == ScoreType.Bullseye) CurrentPlayerLegScore = 0;


### PR DESCRIPTION
### Omschrijving
Logica operatie toegevoegd in leg.SubtractScore() zodat de score niet op 1 kan eindigen.

**Risico's**
Uitermate laag risico, if-statement aangepast.

---
### Tests
**Test 1 "Kan niet eindigen op 1" :**

Voorbereiding:
- Start het programma op.
- Klik op de "Start Match" knop.
- Vul Bip en Bob in bij player one en player two.
- Vul bij het aantal Sets en Legs 1 in.
- Vul bij starting Player Player1 in.
- Klik op de "Start Match" knop.

Test
- Vul bij worp 1 tm 3 Tripple 20 in.
- Klik 2x op de "Next Turn" knop.
- Vul bij worp 1 tm 3 Tripple 20 in.
- Klik 2x op de "Next Turn" knop.
- Vul bij worp 1 & 2 Tripple 20 in, vul bij worp 3 Single 20 in.
- Klik op de "Next Turn" knop.

Geslaagd als :
De Score van Speler 1, 21 is.
