### PR TITLE
#68 Functie om database te resetten.

### DIFF
--- a/DARTS/Data/DataBase/DataBaseProvider.cs
+++ b/DARTS/Data/DataBase/DataBaseProvider.cs
@@ -12,13 +12,13 @@ namespace DARTS.Data.DataBase
         private static DataBaseProvider _instance = null;
         private static readonly object padLock = new object();
 
-        public string DBFileName { get; } = "DARTS_DATABASE.sqlite";
         private SQLiteConnection _dbConnection;        
 
         private static readonly bool IsRunningFromUnittest =
             IsRunningFromUnittest = AppDomain.CurrentDomain.GetAssemblies().Any(
             a => a.FullName.ToLowerInvariant().StartsWith("testhost"));
 
+        public const string DBFileName = "DARTS_DATABASE.sqlite";
         private DataBaseProvider()
         {
             

--- a/DARTS/ViewModel/OptionsMenuViewModel.cs
+++ b/DARTS/ViewModel/OptionsMenuViewModel.cs
@@ -14,7 +14,7 @@ namespace DARTS.ViewModel
 
         public OptionsMenuViewModel()
         {
-            ResetDatabaseButtonClickCommand = new RelayCommand(execute => ResetDatabaseButton_Click(), canExecute => File.Exists(DataBaseProvider.Instance.DBFileName));
+            ResetDatabaseButtonClickCommand = new RelayCommand(execute => ResetDatabaseButton_Click(), canExecute => File.Exists(DataBaseProvider.DBFileName));
             GoBackButtonClickCommand = new RelayCommand(execute => GoBackButton_Click());
         }
 

--- a/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
+++ b/DARTS_UnitTests/Data/DataObjects/Match_UnitTest.cs
@@ -258,8 +258,8 @@ namespace DARTS_UnitTests.Datastructuur
             Assert.IsNotNull(match.Player2SetsWon);
         }
 
-        [ClassCleanup]
-        public static void TestCleanup()
+        [TestCleanup]
+        public void TestCleanup()
         {
             DataBaseProvider.Instance.Dispose();
         }

--- a/DARTS_UnitTests/ViewModel/MatchesOverviewViewModel_UnitTest_RightCharacter.cs
+++ b/DARTS_UnitTests/ViewModel/MatchesOverviewViewModel_UnitTest_RightCharacter.cs
@@ -17,7 +17,6 @@ namespace DARTS_UnitTests.ViewModel
         public static void ClassInitialize(TestContext testContext)
         {
             // Arrange
-            DataBaseProvider.Instance.Dispose();
             Mock_DatabaseTestData.AddDatabaseTestData();
         }
 


### PR DESCRIPTION
### Omschrijving
Functionaliteit zoals beschreven in #68 geïmplementeerd. Bug #85 gefixed.

**Risico's**
Middelmatig risico, database file wordt verwijderd on runtime.

---
### Tests
**Test 1 "Database resetten" :**

Voorbereiding:
- Start het programma op.
- Klik op de "Start Match" knop.
- Klik op de "Back to main menu" knop.
- Controleer of de "DARTS_DATABASE.sqlite" file bestaat in: DARTS\DARTS\bin\Debug\netcoreapp3.1\
- Klik op de "Options" knop

Test
- Klik op de "Reset" knop
- Klik in de pop-up op "OK"
- Controleer of de "Reset" knop niet klikbaar is.

Geslaagd als :
De database gereset is en de "Reset" knop niet klikbaar is en de "DARTS_DATABASE.sqlite" file verwijdert is in: DARTS\DARTS\bin\Debug\netcoreapp3.1\

---
